### PR TITLE
Adopt Swift 6.2 concurrency safety

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:6.1
+// swift-tools-version:6.2
 
 import PackageDescription
 import Foundation

--- a/Sources/DOM/Window.swift
+++ b/Sources/DOM/Window.swift
@@ -8,8 +8,9 @@
 import WebFoundation
 import Events
 
-private var _shared: Window?
+@MainActor private var _shared: Window?
 
+@MainActor
 public class Window: EventListenerCompatibleObject, EventTarget {
     public lazy var storage: Storage = .init()
     public var jsValue: JSValue { domElement }

--- a/Sources/HistoryAPI/History.swift
+++ b/Sources/HistoryAPI/History.swift
@@ -8,9 +8,10 @@
 import WebFoundation
 import LocationAPI
 
-private var _shared: History?
+@MainActor private var _shared: History?
 
 /// [Learn more](https://developer.mozilla.org/en-US/docs/Web/API/History)
+@MainActor
 public final class History: InnerStateChangeable, Equatable {
     public static var shared: History {
         guard let shared = _shared else {

--- a/Sources/LocationAPI/Location.swift
+++ b/Sources/LocationAPI/Location.swift
@@ -7,9 +7,10 @@
 
 import WebFoundation
 
-private var _shared: Location?
+@MainActor private var _shared: Location?
 
 /// [Learn more](https://developer.mozilla.org/en-US/docs/Web/API/Location)
+@MainActor
 public final class Location: InnerStateChangeable, Equatable {
     public static var shared: Location {
         guard let shared = _shared else {

--- a/Sources/ServiceWorker/ServiceWorker.swift
+++ b/Sources/ServiceWorker/ServiceWorker.swift
@@ -8,9 +8,10 @@
 import Foundation
 import JavaScriptKit
 
-private var serviceworker: ServiceWorker!
+@MainActor private var serviceworker: ServiceWorker!
 
 /// [Learn more](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API)
+@MainActor
 open class ServiceWorker {
     private var isStarted = false
     

--- a/Sources/SharedWorker/SharedWorker.swift
+++ b/Sources/SharedWorker/SharedWorker.swift
@@ -9,8 +9,9 @@ import WebFoundation
 import WorkersAPI
 import ChannelMessagingAPI
 
-private var sharedworker: SharedWorker!
+@MainActor private var sharedworker: SharedWorker!
 
+@MainActor
 open class SharedWorker {
     private var isStarted = false
     

--- a/Sources/StorageAPI/LocalStorage.swift
+++ b/Sources/StorageAPI/LocalStorage.swift
@@ -7,8 +7,9 @@
 
 import WebFoundation
 
-private var _shared: LocalStorage?
+@MainActor private var _shared: LocalStorage?
 
+@MainActor
 public final class LocalStorage {
     public static var shared: LocalStorage {
         guard let shared = _shared else {

--- a/Sources/StorageAPI/SessionStorage.swift
+++ b/Sources/StorageAPI/SessionStorage.swift
@@ -7,9 +7,10 @@
 
 import WebFoundation
 
-private var _shared: SessionStorage?
+@MainActor private var _shared: SessionStorage?
 
 // It is more secure to just use swift dictionary, cause it will be not available for user
+@MainActor
 public final class SessionStorage {
     public static var shared: SessionStorage {
         guard let shared = _shared else {

--- a/Sources/Web/Localization/Localization.swift
+++ b/Sources/Web/Localization/Localization.swift
@@ -7,8 +7,9 @@
 
 import Foundation
 
-private var localization = Localization()
+@MainActor private var localization = Localization()
 
+@MainActor
 public class Localization {
     let currentLocaleIdentifier = WebApp.shared.window.navigator.language?.replacingOccurrences(of: "-", with: "_") ?? "en_US"
     

--- a/Sources/Web/URLEncodedForm/URLEncodedFormSerializer.swift
+++ b/Sources/Web/URLEncodedForm/URLEncodedFormSerializer.swift
@@ -79,7 +79,7 @@ extension String {
 }
 
 /// Characters allowed in form-urlencoded data.
-private var _allowedCharacters: CharacterSet = {
+private let _allowedCharacters: CharacterSet = {
     var allowed = CharacterSet.urlQueryAllowed
     // these symbols are reserved for url-encoded form
     allowed.remove(charactersIn: "?&=[];+")

--- a/Sources/Web/WebApp.swift
+++ b/Sources/Web/WebApp.swift
@@ -8,8 +8,9 @@
 import Foundation
 import CSS
 
-private var webapp: WebApp!
+@MainActor private var webapp: WebApp!
 
+@MainActor
 open class WebApp {
     public typealias Configuration = AppBuilder.Content
     

--- a/Sources/WebFoundation/Dispatch.swift
+++ b/Sources/WebFoundation/Dispatch.swift
@@ -8,14 +8,20 @@
 import Foundation
 import JavaScriptKit
 
-private var dispatch = Dispatch()
+@MainActor
+private final class DispatchStorage {
+    var functions: [String: JSClosure] = [:]
+}
 
-public struct Dispatch {
-    fileprivate var functions: [String: JSClosure] = [:]
+@MainActor
+private let dispatchStorage = DispatchStorage()
+
+@MainActor
+public enum Dispatch {
     
     /// Set timeout JavaScript function which executes after 0 seconds.
     /// - Parameter closure: Closure to execute.
-    public static func async(_ closure: @escaping () -> Void) {
+    public static func async(_ closure: @Sendable @escaping () -> Void) {
         asyncAfter(0, closure)
     }
     
@@ -23,7 +29,7 @@ public struct Dispatch {
     /// - Parameters:
     ///   - time: Time in seconds.
     ///   - closure: Closure to execute.
-    public static func asyncAfter(_ time: Double, _ closure: @escaping () -> Void) {
+    public static func asyncAfter(_ time: Double, _ closure: @Sendable @escaping () -> Void) {
         #if arch(wasm32)
         let uid = String.shuffledAlphabet(8)
         var function: JSClosure!
@@ -32,16 +38,19 @@ public struct Dispatch {
             #if JAVASCRIPTKIT_WITHOUT_WEAKREFS
             function.release()
             #endif
-            dispatch.functions[uid] = nil
+            dispatchStorage.functions[uid] = nil
             return .null
         }
-        dispatch.functions[uid] = function
+        dispatchStorage.functions[uid] = function
         _ = JSObject.global.setTimeout!(function, time * 1_000)
         #else
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(Int(time)), execute: closure)
+        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(Int(time))) {
+            closure()
+        }
         #endif
     }
-    
+
+    @MainActor
     public struct IntervalTask {
         let object: JSValue
         let invalidateHandler: () -> Void
@@ -68,7 +77,7 @@ public struct Dispatch {
                 closure(task)
             } else {
                 task = IntervalTask(timer) {
-                    dispatch.functions[uid] = nil
+                    dispatchStorage.functions[uid] = nil
                     #if JAVASCRIPTKIT_WITHOUT_WEAKREFS
                     function.release()
                     #endif
@@ -77,7 +86,7 @@ public struct Dispatch {
             }
             return .null
         }
-        dispatch.functions[uid] = function
+        dispatchStorage.functions[uid] = function
         timer = JSObject.global.setInterval!(function, time * 1_000)
         #endif
     }

--- a/Sources/WebFoundation/URLConformable.swift
+++ b/Sources/WebFoundation/URLConformable.swift
@@ -20,7 +20,7 @@ extension String: URLConformable {
     public var stringValue: String { self }
 }
 
-extension URL: URLConformable {
+@retroactive extension URL: URLConformable {
 	public var stringValue: String { self.absoluteString }
 }
 

--- a/Sources/Worker/Worker.swift
+++ b/Sources/Worker/Worker.swift
@@ -9,8 +9,9 @@ import WebFoundation
 import WorkersAPI
 import ChannelMessagingAPI
 
-private var worker: Worker!
+@MainActor private var worker: Worker!
 
+@MainActor
 open class Worker {
     private var isStarted = false
     


### PR DESCRIPTION
## Summary
- update the package manifest to target Swift 6.2 tooling
- isolate global Web APIs on the main actor and adjust Dispatch utilities for Swift 6.2 concurrency checks
- silence new Swift 6.2 warnings by marking URL conformance retroactively and making shared constants immutable

## Testing
- `swift build` *(fails: Swift 6.2 toolchain required, container provides Swift 6.1)*

------
https://chatgpt.com/codex/tasks/task_e_68d40fad327883308e441df0823734e0